### PR TITLE
Allow dash (-) in webresource names

### DIFF
--- a/WebResourceHelper/WebResourcePartitioner.cs
+++ b/WebResourceHelper/WebResourcePartitioner.cs
@@ -23,7 +23,7 @@ namespace WebResourceHelper
 
     class WebResourcePartitioner
     {
-        private static readonly Regex InvalidWebResourceNameRegex = new Regex(@"[^a-z0-9A-Z_\\./]|[/]{2,}", (RegexOptions.Compiled | RegexOptions.CultureInvariant));
+        private static readonly Regex InvalidWebResourceNameRegex = new Regex(@"[^a-z0-9A-Z-_\\./]|[/]{2,}", (RegexOptions.Compiled | RegexOptions.CultureInvariant));
 
         private readonly WebResourceHelperOptions options;
 


### PR DESCRIPTION
Allow to have a dash (-) in webresource names. This is perfectly valid in webresource names and also urls.